### PR TITLE
Fix 'no image to pull' when dockerfile contains \r

### DIFF
--- a/build.js
+++ b/build.js
@@ -56,7 +56,7 @@ function dockerBuild (dockerFile, opts) {
     }
 
     var from
-    data.toString().split('\n').forEach(function (line) {
+    data.toString().split(/\r?\n/).forEach(function (line) {
       var match = line.match(/^FROM +(.*)$/)
       if (match) {
         from = match[1]


### PR DESCRIPTION
Hi mcollina,

The PR is fix Dockerfile containes '\r\n' on Windows OS . 
Please help to review it.

Thanks,
YT